### PR TITLE
genTime is always NaN

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,8 @@ function safeEqual (str1, str2) {
  * @property {number} TOKENIZE_EPOCH First second of 2019, used to get shorter tokens
  */
 class Tokenize {
-  get VERSION () { return 1 }
-  get TOKENIZE_EPOCH () { return 1546300800000 }
+  static get VERSION () { return 1 }
+  static get TOKENIZE_EPOCH () { return 1546300800000 }
 
   /**
    * Tokenize constructor


### PR DESCRIPTION
Hi @cyyynthia,

Thanks for this great repo, I used it in a side project, and I found the token it generated are always like this:

```
api.NjE4MTI2MzljMDY3ZTg3ZGNhOThhZWE5.TmFO.4dwDk6yoweH9eN0WGtCTQ1DfE7sBZMPPf19JDxSda44
api.NjE4MTYwMDUyZjZmMjA3MWVmNDc4MjY5.TmFO.HMMeIHpl7F3g9EUphJw70t/nyYJ7rkR2mtcIpKJiz3s
api.NjE4MTI2MzljMDY3ZTg3ZGNhOThhZWE5.TmFO.4dwDk6yoweH9eN0WGtCTQ1DfE7sBZMPPf19JDxSda44
```

The genTime part is always `TmFO`, I decoded it, and found it's `NaN`, I looked into the code and find a small bug, the `Tokenize.TOKENIZE_EPOCH` is used as a static getter, but it's defined as instance getter, so I just made a PR, please check.

Thanks!

William